### PR TITLE
Propagate errors

### DIFF
--- a/lambdas/raster_analysis/src/lambda_function.py
+++ b/lambdas/raster_analysis/src/lambda_function.py
@@ -36,7 +36,7 @@ def handler(event, context):
         results_store.save_result(results, context.aws_request_id)
     except Exception as e:
         results_store = AnalysisResultsStore(event["analysis_id"])
-        results_store.save_status(context.aws_request_id, ResultStatus.error)
+        results_store.save_status(context.aws_request_id, ResultStatus.error, str(e))
 
         LOGGER.exception(e)
-        raise Exception(f"Internal Server Error <{context.aws_request_id}>")
+        raise e

--- a/lambdas/tiled_analysis/src/lambda_function.py
+++ b/lambdas/tiled_analysis/src/lambda_function.py
@@ -24,7 +24,7 @@ def handler(event, context):
         LOGGER.info("Successfully merged tiled results")
         return {"status": "success", "data": results}
     except QueryParseException as e:
-        return {"status": "fail", "message": str(e)}
+        return {"status": "failed", "message": str(e)}
     except Exception as e:
         LOGGER.exception(e)
         return {"status": "error", "message": str(e)}

--- a/lambdas/tiled_analysis/src/lambda_function.py
+++ b/lambdas/tiled_analysis/src/lambda_function.py
@@ -1,4 +1,5 @@
 from raster_analysis.data_environment import DataEnvironment
+from raster_analysis.exceptions import QueryParseException
 from raster_analysis.globals import LOGGER
 from raster_analysis.tiling import AnalysisTiler
 
@@ -21,7 +22,9 @@ def handler(event, context):
             results = tiler.result_as_dict()
 
         LOGGER.info("Successfully merged tiled results")
-        return {"statusCode": 200, "body": {"status": "success", "data": results}}
+        return {"status": "success", "data": results}
+    except QueryParseException as e:
+        return {"status": "fail", "message": str(e)}
     except Exception as e:
         LOGGER.exception(e)
-        return {"statusCode": 500, "body": {"status": "failed", "message": str(e)}}
+        return {"status": "error", "message": str(e)}

--- a/raster_analysis/data_environment.py
+++ b/raster_analysis/data_environment.py
@@ -1,8 +1,7 @@
 # flake8: noqa
 import json
 from collections import Iterable, defaultdict
-from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Type, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from numpy import (
     ceil,
@@ -20,7 +19,8 @@ from numpy import (
 from pandas import Series
 from pydantic import BaseModel
 
-from raster_analysis.globals import BasePolygon
+from raster_analysis.exceptions import QueryParseException
+from raster_analysis.globals import LOGGER, BasePolygon
 from raster_analysis.grid import Grid, GridName, TileScheme
 
 
@@ -77,9 +77,10 @@ class DataEnvironment(BaseModel):
             if layer.name == name:
                 return layer
 
-        raise KeyError(
+        LOGGER.error(
             f"Could not find layer with name {name} in data environment {json.dumps(self.dict())}"
         )
+        raise QueryParseException(f"Layer {name} is invalid")
 
     def get_layer_grid(self, name: str) -> Grid:
         layer = self.get_layer(name)
@@ -148,6 +149,8 @@ class DataEnvironment(BaseModel):
         elif layer.decode_expression:
             A = values
             return eval(layer.decode_expression)
+        else:
+            return values
 
     def get_source_uri(self, name: str, tile: BasePolygon):
         layer = self.get_layer(name)

--- a/raster_analysis/query.py
+++ b/raster_analysis/query.py
@@ -62,11 +62,18 @@ class Query:
     def __init__(self, query: str, data_environment: DataEnvironment):
         self.data_environment = data_environment
         base, selectors, filters, groups, aggregates = self.parse_query(query)
+
         self.base = base
         self.selectors = selectors
         self.filters = filters
         self.groups = groups
         self.aggregates = aggregates
+
+        self.validate_query()
+
+    def validate_query(self):
+        layer_names = self.get_layer_names()
+        self.data_environment.get_layers(layer_names)
 
     def get_source_layers(self) -> List[Layer]:
         layer_names = self.get_layer_names()
@@ -181,7 +188,7 @@ class Query:
                         group = Selector(layer=layer_name, function=func_name)
                         groups.append(group)
                     else:
-                        raise ValueError(
+                        raise QueryParseException(
                             f"Unsupported function {func_name} for selector {layer_name} in GROUP BY"
                         )
                 elif isinstance(group["value"], str):

--- a/tests/e2e/test_raster_analysis.py
+++ b/tests/e2e/test_raster_analysis.py
@@ -260,7 +260,7 @@ def test_error(context):
     end = datetime.now()
 
     timeout = timedelta(seconds=29)
-    assert result["status"] == "fail"
+    assert result["status"] == "failed"
     assert (end - start) < timeout
 
 

--- a/tests/e2e/test_raster_analysis.py
+++ b/tests/e2e/test_raster_analysis.py
@@ -104,7 +104,7 @@ def test_primary_tree_cover_loss(context):
     result = tiled_handler(
         {"geometry": IDN_24_9_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
 
     assert result["status"] == "success"
     assert result["data"]
@@ -120,7 +120,7 @@ def test_extent_2010(context):
     result = tiled_handler(
         {"geometry": IDN_24_9_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
     assert result["status"] == "success"
 
     assert result["data"][0]["area__ha"] == pytest.approx(
@@ -138,7 +138,7 @@ def test_lat_lon(context):
             "environment": DATA_ENVIRONMENT,
         },
         context,
-    )["body"]
+    )
     assert result["status"] == "success"
 
     lines = result["data"].splitlines()
@@ -151,7 +151,7 @@ def test_raw_area(context):
     result = tiled_handler(
         {"geometry": IDN_24_9_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
 
     assert result["status"] == "success"
     assert result["data"][0]["area__ha"] == pytest.approx(
@@ -169,7 +169,7 @@ def test_tree_cover_gain(context, monkeypatch):
     result = tiled_handler(
         {"geometry": IDN_24_9_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
 
     assert result["status"] == "success"
     assert result["data"][0]["area__ha"] == pytest.approx(
@@ -182,7 +182,7 @@ def test_tree_cover_loss_by_driver(context):
     result = tiled_handler(
         {"geometry": IDN_24_9_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
 
     assert result["status"] == "success"
     for row_actual, row_expected in zip(result["data"], IDN_24_9_LOSS_BY_DRIVER):
@@ -194,7 +194,7 @@ def test_glad_alerts(context):
     result = tiled_handler(
         {"geometry": IDN_24_9_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
 
     assert result["status"] == "success"
     for row_actual, row_expected in zip(result["data"], IDN_24_9_GLAD_ALERTS):
@@ -206,7 +206,7 @@ def test_glad_alerts_count(context):
     result = tiled_handler(
         {"geometry": IDN_24_9_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
 
     assert result["status"] == "success"
     for row_actual, row_expected in zip(result["data"], IDN_24_9_GLAD_ALERTS):
@@ -219,7 +219,7 @@ def test_radd_alerts(context):
     result = tiled_handler(
         {"geometry": COD_21_4_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
 
     assert result["status"] == "success"
 
@@ -230,7 +230,7 @@ def test_glad_s2_alerts(context):
     result = tiled_handler(
         {"geometry": BRA_14_87_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
 
     assert result["status"] == "success"
 
@@ -240,7 +240,7 @@ def test_land_cover_area(context):
     result = tiled_handler(
         {"geometry": IDN_24_9_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
 
     assert result["status"] == "success"
     for row_actual, row_expected in zip(result["data"], IDN_24_9_ESA_LAND_COVER):
@@ -256,11 +256,11 @@ def test_error(context):
     result = tiled_handler(
         {"geometry": IDN_24_9_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
         context,
-    )["body"]
+    )
     end = datetime.now()
 
     timeout = timedelta(seconds=29)
-    assert result["status"] == "failed"
+    assert result["status"] == "fail"
     assert (end - start) < timeout
 
 
@@ -271,7 +271,7 @@ def test_beyond_extent(context):
     query = "select sum(area__ha) from is__umd_regional_primary_forest_2001 group by umd_tree_cover_loss__year"
     result = tiled_handler(
         {"geometry": geometry, "query": query, "environment": DATA_ENVIRONMENT}, context
-    )["body"]
+    )
 
     assert result["status"] == "success"
     assert not result["data"]


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Most errors are swallowed and just say "check logs". Error status is returned via "statusCode" parameter that isn't used anywhere.



## What is the new behavior?

- Don't return with "statusCode" and "body" anymore. I thought this would change the status code of the lambda response, but that only works with API Gateway, which we don't use anymore. With boto3, Lambda will always return 200 unless there was a specific error with the Lambda service (e.g. hit concurrency limit). 
- Instead, return correct JSEND response. Status should be "fail" if there was a validation error, and "error" if there was an exception while processing.
- Validate all layers exist in the query and propagate query parse errors with status "fail" and a useful message for debugging.
- Propagate errors for parallelized lambdas by returning a "detail" field in the status DynamoDB table.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


