### PR TITLE
Factor entire payload size when checking if we should compress the geometry

### DIFF
--- a/raster_analysis/tiling.py
+++ b/raster_analysis/tiling.py
@@ -133,8 +133,7 @@ class AnalysisTiler:
         payload["geometry"] = self.raw_geom
         if sys.getsizeof(json.dumps(payload)) > LAMBDA_ASYNC_PAYLOAD_LIMIT_BYTES:
             # if payload would be too big, compress geometry
-            del payload["geometry"]
-            payload["encoded_geometry"] = encode_geometry(self.geom)
+            payload["encoded_geometry"] = encode_geometry(payload.pop("geometry"))
 
         results_store = AnalysisResultsStore()
         tile_keys = [

--- a/raster_analysis/tiling.py
+++ b/raster_analysis/tiling.py
@@ -130,10 +130,11 @@ class AnalysisTiler:
             "environment": self.data_environment.dict(),
         }
 
-        if sys.getsizeof(json.dumps(self.raw_geom)) > LAMBDA_ASYNC_PAYLOAD_LIMIT_BYTES:
+        payload["geometry"] = self.raw_geom
+        if sys.getsizeof(json.dumps(payload)) > LAMBDA_ASYNC_PAYLOAD_LIMIT_BYTES:
+            # if payload would be too big, compress geometry
+            del payload["geometry"]
             payload["encoded_geometry"] = encode_geometry(self.geom)
-        else:
-            payload["geometry"] = self.raw_geom
 
         results_store = AnalysisResultsStore()
         tile_keys = [


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
If the input geometry is bigger than payload limit for asynchronous lambda calls, we compress the geometry. But that doesn't check the rest of the payload, like the data environment, which may also be a few kilobytes. If the input geometry is close to, but still less than, the size limit, the rest of the payload can push it over, causing an error.

Issue Number: GTC-2116


## What is the new behavior?
Check the entire payload size when checking if we should compress the geometry.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


