### PR TITLE
Handle empty geometries after tile intersections correctly

### DIFF
--- a/lambdas/raster_analysis/src/lambda_function.py
+++ b/lambdas/raster_analysis/src/lambda_function.py
@@ -32,7 +32,7 @@ def handler(event, context):
 
         if not geom_tile.geom:
             LOGGER.info(f"Geometry for tile {context.aws_request_id} is empty.")
-            results_store.save_result({}, context.aws_request_id)
+            results_store.save_result(DataFrame(), context.aws_request_id)
             return {}
 
         data_environment = DataEnvironment(layers=event["environment"])

--- a/raster_analysis/geometry.py
+++ b/raster_analysis/geometry.py
@@ -2,10 +2,10 @@ import sys
 from typing import Any, Dict
 
 import geobuf
-from shapely.geometry import shape, Polygon, mapping
+from shapely.geometry import Polygon, mapping, shape
 
 from raster_analysis.exceptions import InvalidGeometryException
-from raster_analysis.globals import BasePolygon, LAMBDA_ASYNC_PAYLOAD_LIMIT_BYTES
+from raster_analysis.globals import LAMBDA_ASYNC_PAYLOAD_LIMIT_BYTES, BasePolygon
 
 
 class GeometryTile:
@@ -37,16 +37,11 @@ class GeometryTile:
                         f"Could not create valid tile from geom {full_geom.wkt} and tile {tile.wkt}"
                     )
 
-            if geom_tile.is_empty:
-                self.geom = {}
-
             self.geom = geom_tile
 
 
 def encode_geometry(geom: BasePolygon) -> str:
-    """
-    Encode geometry into a compressed string
-    """
+    """Encode geometry into a compressed string."""
     encoded_geom = geobuf.encode(mapping(geom)).hex()
 
     # if the geometry is so complex is still goes over the limit, incrementally attempting to simplify it
@@ -64,7 +59,5 @@ def encode_geometry(geom: BasePolygon) -> str:
 
 
 def decode_geometry(geom: str) -> BasePolygon:
-    """
-    Decode geometry from compressed string
-    """
+    """Decode geometry from compressed string."""
     return shape(geobuf.decode(bytes.fromhex(geom))).buffer(0)

--- a/raster_analysis/tiling.py
+++ b/raster_analysis/tiling.py
@@ -124,7 +124,6 @@ class AnalysisTiler:
         return results
 
     def _execute_tiles(self) -> DataFrame:
-        tiles = self._get_tiles(self.grid.tile_degrees)
         payload: Dict[str, Any] = {
             "query": self.raw_query,
             "environment": self.data_environment.dict(),
@@ -134,6 +133,8 @@ class AnalysisTiler:
         if sys.getsizeof(json.dumps(payload)) > LAMBDA_ASYNC_PAYLOAD_LIMIT_BYTES:
             # if payload would be too big, compress geometry
             payload["encoded_geometry"] = encode_geometry(payload.pop("geometry"))
+
+        tiles = self._get_tiles(self.grid.tile_degrees)
 
         results_store = AnalysisResultsStore()
         tile_keys = [

--- a/raster_analysis/tiling.py
+++ b/raster_analysis/tiling.py
@@ -132,7 +132,8 @@ class AnalysisTiler:
         payload["geometry"] = self.raw_geom
         if sys.getsizeof(json.dumps(payload)) > LAMBDA_ASYNC_PAYLOAD_LIMIT_BYTES:
             # if payload would be too big, compress geometry
-            payload["encoded_geometry"] = encode_geometry(payload.pop("geometry"))
+            geom = shape(payload.pop("geometry"))
+            payload["encoded_geometry"] = encode_geometry(geom)
 
         tiles = self._get_tiles(self.grid.tile_degrees)
 


### PR DESCRIPTION
This is a corner case where a large and complicated geometry had one tile intersection become an empty polygon after making it valid (it probably created a thin sliver). The code path for handling this corner case was invalid.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
On getting an empty polygon intersection, the lambdas tries to return an empty dictionary instead of an empty pandas DataFrame as the result. This causes an exception on saving the result to DynamoDB when it tries get its shape. 

Issue Number: GTC-2458


## What is the new behavior?

- Return an empty pandas DataFrame in this case.
- Remove an unnecessary line of code that wasn't actually ever working.
- The pre-commit hooks picked up some formatting changes.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

