### PR TITLE
GTC-2950 Remove WarpedVRT usage in OTF lambda

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,3 +21,7 @@ protobuf==3.20.3
 pyproj==3.6.0
 rasterio[s3]==1.3.8
 shapely==1.8.5.post1
+codeguru-profiler-agent==1.2.5
+mo_parsing==8.*
+mo_sql_parsing==9.436.23241
+numpy==1.26

--- a/tests/e2e/test_raster_analysis.py
+++ b/tests/e2e/test_raster_analysis.py
@@ -31,6 +31,7 @@ from tests.fixtures.fixtures import (
     COD_21_4_GEOM,
     COD_24_1_TCLF,
     DATA_ENVIRONMENT,
+    DATA_ENVIRONMENT_10M,
     IDN_24_9_2010_EXTENT,
     IDN_24_9_2010_RAW_AREA,
     IDN_24_9_2019_GLAD_ALERTS_TOTAL,
@@ -246,7 +247,7 @@ def test_radd_alerts(context):
     # TODO calculate number of alerts offline
     query = "select latitude, longitude, gfw_radd_alerts__date, gfw_radd_alerts__confidence from gfw_radd_alerts__date where is__umd_regional_primary_forest_2001 = 'true' and gfw_radd_alerts__date >= '2021-01-01'"
     result = tiled_handler(
-        {"geometry": COD_21_4_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
+        {"geometry": COD_21_4_GEOM, "query": query, "environment": DATA_ENVIRONMENT_10M},
         context,
     )
 
@@ -257,7 +258,7 @@ def test_glad_s2_alerts(context):
     # TODO calculate number of alerts offline
     query = "select latitude, longitude, umd_glad_sentinel2_alerts__date, umd_glad_sentinel2_alerts__confidence from umd_glad_sentinel2_alerts__date where is__umd_regional_primary_forest_2001 = 'true' and umd_glad_sentinel2_alerts__date >= '2021-03-01'"
     result = tiled_handler(
-        {"geometry": BRA_14_87_GEOM, "query": query, "environment": DATA_ENVIRONMENT},
+        {"geometry": BRA_14_87_GEOM, "query": query, "environment": DATA_ENVIRONMENT_10M},
         context,
     )
 

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -188,6 +188,34 @@ DATA_ENVIRONMENT = [
         },
     },
     {
+        "source_uri": "s3://gfw-data-lake/umd_tree_cover_loss_from_fires/v20220309/raster/epsg-4326/10/40000/is/geotiff/{tile_id}.tif",
+        "tile_scheme": "nw",
+        "grid": "10/40000",
+        "name": "is__umd_tree_cover_loss_from_fires",
+        "raster_table": {
+            "rows": [{"value": 0, "meaning": "false"}, {"value": 1, "meaning": "true"}]
+        },
+    },
+    {
+        "source_uri": "s3://gfw-data-lake/wri_tropical_tree_cover/v2020/raster/epsg-4326/10/40000/percent/geotiff/{tile_id}.tif",
+        "tile_scheme": "nw",
+        "grid": "10/40000",
+        "name": "wri_tropical_tree_cover__percent",
+        "no_data": 255,
+    },
+]
+
+DATA_ENVIRONMENT_10M = [
+    {
+        "source_uri": "s3://gfw-data-lake/umd_regional_primary_forest_2001/v201901/raster/epsg-4326/10/100000/is/geotiff/{tile_id}.tif",
+        "tile_scheme": "nw",
+        "grid": "10/100000",
+        "name": "is__umd_regional_primary_forest_2001",
+        "raster_table": {
+            "rows": [{"value": 0, "meaning": "false"}, {"value": 1, "meaning": "true"}]
+        },
+    },
+    {
         "source_uri": "s3://gfw-data-lake/umd_glad_sentinel2_alerts/v20210406/raster/epsg-4326/10/100000/date_conf/geotiff/{tile_id}.tif",
         "tile_scheme": "nw",
         "grid": "10/100000",
@@ -228,22 +256,6 @@ DATA_ENVIRONMENT = [
         "raster_table": {
             "rows": [{"value": 2, "meaning": ""}, {"value": 3, "meaning": "high"}]
         },
-    },
-    {
-        "source_uri": "s3://gfw-data-lake/umd_tree_cover_loss_from_fires/v20220309/raster/epsg-4326/10/40000/is/geotiff/{tile_id}.tif",
-        "tile_scheme": "nw",
-        "grid": "10/40000",
-        "name": "is__umd_tree_cover_loss_from_fires",
-        "raster_table": {
-            "rows": [{"value": 0, "meaning": "false"}, {"value": 1, "meaning": "true"}]
-        },
-    },
-    {
-        "source_uri": "s3://gfw-data-lake/wri_tropical_tree_cover/v2020/raster/epsg-4326/10/40000/percent/geotiff/{tile_id}.tif",
-        "tile_scheme": "nw",
-        "grid": "10/40000",
-        "name": "wri_tropical_tree_cover__percent",
-        "no_data": 255,
     },
 ]
 


### PR DESCRIPTION
GTC-2950 Remove unneeded WarpedVRT usage in OTF lambda

It looks like WarpedVRT was added to deal with the case where not all layers in an OTF query were on the same grid. But for a long time, the layers that can be used in an OTF query and are sent in the data_environment by the Data API must all be on the same grid as the primary dataset. So, we can remove the use of WarpedVRT. I didn't remove the grid argument in many of these functions, even though it is no longer used.

I also some unused imports and several long-commented-out lines (related to grids).

We had two tests test_radd_alerts and test_glad_s2_alerts that were mainly using a 10/100000 grid but references a layer with a 10/40000 grid. So, I created a new DATA_ENVIRONMENT_10M with only 10/100000 layers, and used that instead for those two tests.

I also fixed up requirements-dev.txt, which was missing some recently added layers that needed to be installed locally. I think in Github tests, those are otherwise installed by setup.py, but that isn't used if you just do "pipenv install -r requirements-dev.txt" locally.

