### PR TITLE
Fix multiple decode of date values caused by inconsistent hash and eq methods

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = asyncclick,aws_xray_sdk,boto3,geobuf,geopandas,http3,mo_parsing,mo_sql_parsing,numpy,pandas,pydantic,pytest,rasterio,setuptools,shapely
+known_third_party = asyncclick,aws_xray_sdk,boto3,geobuf,geopandas,httpx,mo_parsing,mo_sql_parsing,numpy,pandas,pydantic,pytest,rasterio,requests,shapely

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,33 +10,33 @@ repos:
     hooks:
     - id: isort
 -   repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+    rev: v1.7.8
     hooks:
     - id: docformatter
       args: [--in-place]
 -   repo: https://github.com/ambv/black
-    rev: 23.7.0
+    rev: 26.3.1
     hooks:
     - id: black
       language_version: python3.10
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
     - id: detect-aws-credentials
     - id: detect-private-key
     - id: trailing-whitespace
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.3.0
     hooks:
     - id: flake8
       language_version: python3.10
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.20.1
     hooks:
     -   id: mypy
         language_version: python3.10
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline'] # run: `pip install detect-secrets` to establish baseline

--- a/raster_analysis/query.py
+++ b/raster_analysis/query.py
@@ -23,6 +23,7 @@ try:
     from enum import StrEnum
 except ImportError:
     from enum import Enum
+
     class StrEnum(str, Enum):
         pass
 
@@ -127,6 +128,28 @@ class Selector(BaseModel):
     def __hash__(self):
         return hash(self.layer)
 
+    def __eq__(self, other: object) -> bool:
+        # `alias` is purely presentational (it drives column renaming at the
+        # end of postprocessing) and must NOT influence deduplication.
+        #
+        # Without this override, Pydantic's default __eq__ compares every
+        # field, so Selector(layer="x", alias="y") != Selector(layer="x").
+        # That makes dict.fromkeys — which uses both hash() AND == to detect
+        # duplicates — silently keep both selectors when they share a layer
+        # but differ only in alias (e.g. SELECT date AS d … GROUP BY date).
+        #
+        # _postprocess_results then calls decode_layer() once per selector,
+        # hitting the column twice: the second call receives already-decoded
+        # date strings and A.astype("timedelta64[D]") calls
+        # pd.to_timedelta("2026-01-01"), raising:
+        #   ValueError: only leading negative signs are allowed
+        #
+        # Keeping __eq__ consistent with __hash__ (layer only) ensures
+        # dict.fromkeys removes the duplicate and decode_layer is called once.
+        if isinstance(other, Selector):
+            return self.layer == other.layer
+        return NotImplemented
+
 
 class Query:
     def __init__(self, query: str, data_environment: DataEnvironment):
@@ -226,7 +249,6 @@ class Query:
 
         return base, selectors, where, groups, aggregates, order_by, sort, limit
 
-
     def _parse_where(self, query: ParseResults) -> Filter:
         if "where" in query:
             return _parse_filter(query["where"], self.data_environment)
@@ -234,9 +256,7 @@ class Query:
         return Filter()
 
 
-def _parse_select(
-    query: ParseResults
-) -> Tuple[List[Selector], List[Aggregate]]:
+def _parse_select(query: ParseResults) -> Tuple[List[Selector], List[Aggregate]]:
     selectors: List[Selector] = []
     aggregates: List[Aggregate] = []
     for selector in _ensure_list(query["select"]):
@@ -296,7 +316,9 @@ def _parse_group_by(query: ParseResults) -> List[Selector]:
             if isinstance(group_value, dict):
                 func_name, layer_name = _get_first_key_value(group_value)
                 if func_name in Function.__members__.values():
-                    groups.append(Selector(layer=layer_name, function=Function(func_name)))
+                    groups.append(
+                        Selector(layer=layer_name, function=Function(func_name))
+                    )
                 else:
                     raise QueryParseException(
                         f"Unsupported function '{func_name}' for layer '{layer_name}' in GROUP BY. "

--- a/tests/unit/raster_analysis/test_query.py
+++ b/tests/unit/raster_analysis/test_query.py
@@ -1,7 +1,17 @@
+import numpy as np
+import pandas as pd
 import pytest
 
+from raster_analysis.data_environment import DataEnvironment
 from raster_analysis.exceptions import QueryParseException
-from raster_analysis.query import Function, _parse_group_by, _parse_order_by, Sort
+from raster_analysis.query import (
+    Function,
+    Query,
+    Selector,
+    Sort,
+    _parse_group_by,
+    _parse_order_by,
+)
 
 
 class TestParseGroupBy:
@@ -57,7 +67,6 @@ class TestParseGroupBy:
         for supported in Function.__members__.values():
             assert supported in error_message
 
-
     def test_raises_on_int_value(self):
         """
         If group["value"] is neither a dict nor a str — for example an int
@@ -89,7 +98,6 @@ class TestParseGroupBy:
 
         error_message = str(exc_info.value)
         assert "list" in error_message
-
 
     # ---------------------------------------------------------------------------
     # Sanity checks: valid inputs still work correctly
@@ -191,9 +199,9 @@ class TestParseOrderBy:
         _, sort = _parse_order_by(parsed)
 
         assert sort == Sort.asc
-        assert isinstance(sort, Sort), (
-            f"Expected Sort enum, got {type(sort).__name__}: {sort!r}"
-        )
+        assert isinstance(
+            sort, Sort
+        ), f"Expected Sort enum, got {type(sort).__name__}: {sort!r}"
 
     def test_parsed_desc_sort_is_sort_enum(self):
         parsed = {
@@ -283,3 +291,255 @@ class TestParseOrderBy:
 
         assert len(order_bys) == 2
         assert sort == Sort.desc
+
+
+class TestDateFilterEncoding:
+    """
+    Regression tests for the production bug:
+
+        ValueError: only leading negative signs are allowed
+
+    Root cause
+    ----------
+    ``Selector.__hash__`` hashes only ``layer``, but Pydantic's default
+    ``__eq__`` compares all fields including ``alias``. ``dict.fromkeys``
+    removes a key as duplicate only when both its hash AND equality match a
+    key already in the dict.
+
+    Because the SELECT clause produces ``Selector(layer=..., alias='date')``
+    and the GROUP BY clause produces ``Selector(layer=..., alias=None)``, the
+    two objects have the same hash but are *not equal* under Pydantic's eq.
+    ``dict.fromkeys`` therefore keeps both, and ``Query.get_result_selectors``
+    returns a list with two entries for the same layer.
+
+    ``AnalysisTiler._postprocess_results`` loops over that list and calls
+    ``DataEnvironment.decode_layer`` once per selector. The first call
+    correctly converts uint16 pixel offsets (e.g. ``4019``) to ISO date
+    strings (``'2026-01-01'``). The second call then tries to decode those
+    already-decoded strings using the expression::
+
+        A.astype('timedelta64[D]') + datetime64('2015-01-01', 'D')
+
+    Pandas calls ``pd.to_timedelta('2026-01-01')`` internally, and its
+    timedelta parser rejects the ``-`` separators at non-leading positions:
+
+        ValueError: only leading negative signs are allowed
+
+    Fix
+    ---
+    Add ``Selector.__eq__`` so it matches ``Selector.__hash__`` — both use
+    ``layer`` only. ``alias`` is a presentational concern (column renaming at
+    the very end of postprocessing) and must not affect deduplication.
+    """
+
+    # These are the exact decode/encode expressions that gfw-data-api generates
+    # in _get_date_conf_derived_layers() for every alert date layer.
+    _DECODE_EXPRESSION = (
+        "(A.astype('timedelta64[D]') + datetime64('2015-01-01', 'D')).astype(str)"
+    )
+    _ENCODE_EXPRESSION = (
+        "(datetime64(A, 'D') - datetime64('2015-01-01', 'D')).astype(uint16)"
+    )
+
+    _ALERT_DATE_CONF_SOURCE = {
+        "source_uri": "s3://bucket/{tile_id}.tif",
+        "tile_scheme": "nw",
+        "grid": "10/100000",
+        "name": "gfw_integrated_alerts__date_conf",
+    }
+
+    _ALERT_DATE_DERIVED = {
+        "source_layer": "gfw_integrated_alerts__date_conf",
+        "name": "gfw_integrated_alerts__date",
+        "calc": "A % 10000",
+        "decode_expression": _DECODE_EXPRESSION,
+        "encode_expression": _ENCODE_EXPRESSION,
+    }
+
+    # The problematic query from production.
+    _PRODUCTION_QUERY = (
+        "SELECT gfw_integrated_alerts__date AS date, COUNT(*) AS alert_count "
+        "FROM gfw_integrated_alerts__date "
+        "WHERE gfw_integrated_alerts__date >= '2026-01-01' "
+        "GROUP BY gfw_integrated_alerts__date "
+        "ORDER BY gfw_integrated_alerts__date"
+    )
+
+    def _make_env(self):
+        return DataEnvironment(
+            layers=[self._ALERT_DATE_CONF_SOURCE, self._ALERT_DATE_DERIVED]
+        )
+
+    # ------------------------------------------------------------------
+    # Bug-demonstrating tests (these FAIL before the fix, PASS after)
+    # ------------------------------------------------------------------
+
+    def test_selector_eq_is_inconsistent_with_hash(self):
+        """
+        Selector.__hash__ uses only layer, but Pydantic's default __eq__
+        uses all fields. Two selectors that differ only in alias therefore
+        have the same hash but compare as unequal.
+
+        This inconsistency means dict.fromkeys cannot deduplicate them, so
+        get_result_selectors() returns both the SELECT selector (alias='date')
+        and the GROUP BY selector (alias=None) for the same column, causing
+        decode_layer() to be called twice and raising the production error.
+
+        After the fix, __eq__ also uses only layer, so this assertion passes.
+        """
+        s_with_alias = Selector(layer="gfw_integrated_alerts__date", alias="date")
+        s_no_alias = Selector(layer="gfw_integrated_alerts__date", alias=None)
+
+        assert hash(s_with_alias) == hash(
+            s_no_alias
+        ), "Selectors for the same layer must have the same hash"
+        assert s_with_alias == s_no_alias, (
+            "Selectors for the same layer must compare as equal so that "
+            "dict.fromkeys deduplicates them. alias is presentational only."
+        )
+
+    def test_get_result_selectors_deduplicates_select_alias_and_group_by(self):
+        """
+        When the same column appears in SELECT (with AS alias) and GROUP BY
+        (without alias), get_result_selectors() must return exactly one
+        Selector — not two.
+
+        Returning two causes decode_layer() to be called twice on the same
+        DataFrame column, producing:
+            ValueError: only leading negative signs are allowed
+        """
+        env = self._make_env()
+        q = Query(self._PRODUCTION_QUERY, env)
+
+        result_selectors = q.get_result_selectors()
+
+        assert len(result_selectors) == 1, (
+            f"Expected 1 selector for the date column, got {len(result_selectors)}: "
+            + str([(s.layer, s.alias) for s in result_selectors])
+        )
+        assert result_selectors[0].layer == "gfw_integrated_alerts__date"
+        # The alias from SELECT must be preserved for later column renaming.
+        assert (
+            result_selectors[0].alias == "date"
+        ), "The retained selector should be the one with the alias (from SELECT)"
+
+    # ------------------------------------------------------------------
+    # Direct reproduction of the production error
+    # ------------------------------------------------------------------
+
+    def test_double_decode_raises_the_production_valueerror(self):
+        """
+        Calling decode_layer() twice on the same date column — exactly what
+        the bug causes — reproduces the production error.
+
+        First decode: uint16 pixel offsets → ISO date strings (correct).
+        Second decode: date strings → pd.to_timedelta('2026-01-01') → raises
+            ValueError: only leading negative signs are allowed
+        """
+        env = self._make_env()
+
+        pixel_series = pd.Series([4019, 4020], dtype=np.uint16)
+        date_strings = env.decode_layer("gfw_integrated_alerts__date", pixel_series)
+        assert date_strings.tolist() == ["2026-01-02", "2026-01-03"]
+
+        with pytest.raises(ValueError, match="only leading negative signs are allowed"):
+            env.decode_layer("gfw_integrated_alerts__date", date_strings)
+
+    # ------------------------------------------------------------------
+    # Fix-verification tests (should always pass)
+    # ------------------------------------------------------------------
+
+    def test_encode_converts_date_string_to_uint16_pixel_offset(self):
+        """
+        encode_layer must convert an ISO date string to the uint16 pixel
+        offset stored in the raster (days since 2015-01-01).
+        2026-01-01 is 4019 days after 2015-01-01 → uint16(4019).
+        """
+        env = self._make_env()
+        encoded = env.encode_layer("gfw_integrated_alerts__date", "2026-01-01")
+
+        assert len(encoded) == 1
+        assert isinstance(
+            encoded[0], np.uint16
+        ), f"Expected numpy.uint16, got {type(encoded[0]).__name__}"
+        assert encoded[0] == np.uint16(4018)
+
+    def test_decode_is_inverse_of_encode(self):
+        """
+        Encoding a date to a pixel value and decoding it back must round-trip
+        to the original date string.
+        """
+        env = self._make_env()
+        for date_str in ["2026-01-01", "2025-06-15", "2024-12-31"]:
+            encoded = env.encode_layer("gfw_integrated_alerts__date", date_str)
+            decoded = env.decode_layer(
+                "gfw_integrated_alerts__date",
+                pd.Series(encoded, dtype=np.uint16),
+            )
+            assert decoded.iloc[0] == date_str, (
+                f"Round-trip failed for '{date_str}': "
+                f"encoded to {encoded[0]}, decoded to '{decoded.iloc[0]}'"
+            )
+
+    def test_filter_apply_produces_correct_mask(self):
+        """
+        The full filter chain (parse -> encode -> apply) must produce a
+        correct boolean mask using the production encode_expression.
+
+        Pixel values:
+            3900 ~ 2025-09-05  (before 2026-01-01) -> excluded
+            4019 = 2026-01-01  (boundary)           -> included
+            4020 = 2026-01-02  (after boundary)     -> included
+            4000 ~ 2025-11-06  (before 2026-01-01)  -> excluded
+        """
+        from raster_analysis.query import _parse_filter
+
+        env = self._make_env()
+        where_clause = {
+            "gte": ["gfw_integrated_alerts__date", {"literal": "2026-01-01"}]
+        }
+        raster = np.array([[3900, 4018], [4019, 4000]], dtype=np.uint16)
+
+        class _MockWindow:
+            def __init__(self, data):
+                self.data = data
+
+        filter_node = _parse_filter(where_clause, env)
+        mask = filter_node.apply(
+            tile_width=2,
+            windows={"gfw_integrated_alerts__date": _MockWindow(raster)},
+        )
+
+        assert mask.shape == raster.shape
+        assert bool(mask[0, 0]) is False, "3900 (~2025-09-05) should be excluded"
+        assert bool(mask[0, 1]) is True, "4018 (2026-01-01 boundary) should be included"
+        assert bool(mask[1, 0]) is True, "4019 (2026-01-02) should be included"
+        assert bool(mask[1, 1]) is False, "4000 (~2025-11-06) should be excluded"
+
+    def test_no_double_decode_after_fix(self):
+        """
+        After the fix, iterating over get_result_selectors() and calling
+        decode_layer() once per selector must succeed with no double-decode.
+
+        This simulates the decode loop in AnalysisTiler._postprocess_results.
+        """
+        env = self._make_env()
+        q = Query(self._PRODUCTION_QUERY, env)
+
+        raw = pd.DataFrame(
+            {
+                "gfw_integrated_alerts__date": pd.Series(
+                    [4019, 4020, 4019], dtype=np.int64
+                ),
+                "count": pd.Series([5, 3, 7], dtype=np.int64),
+            }
+        )
+
+        for selector in q.get_result_selectors():
+            raw[selector.layer] = env.decode_layer(selector.layer, raw[selector.layer])
+
+        assert raw["gfw_integrated_alerts__date"].tolist() == [
+            "2026-01-02",
+            "2026-01-03",
+            "2026-01-02",
+        ]


### PR DESCRIPTION
This fixes a subtle bug found by a user in production.
The Selector class has __hash__ overridden to deduplicate layers, but not __eq__. This inconsistency causes two selectors to be kept, and _postprocess_results to attempt to decode the date column twice. The first time goes from uint16 (typical date_conf offset, like 254) to stringified date like "2026-01-01". The second time Pandas tries to convert THAT into a timedelta, and that blows up.
Tests included.